### PR TITLE
Fix build.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,10 +23,11 @@
     repo: https://github.com/phpredis/phpredis.git
     dest: "/var/lib/ansible/phpredis/checkouts/phpredis"
     version: "{{ phpredis_version }}"
+    force: yes
   tags: [configuration, phpredis, phpredis-checkout]
 
 - name: build deb file
-  shell: "/var/lib/ansible/phpredis/checkouts/phpredis/mkdeb.sh && mv /var/lib/ansible/phpredis/checkouts/phpredis/phpredis-{{ phpredis_version }}_{{ ansible_machine }}.deb /var/lib/ansible/phpredis/checkouts/phpredis-{{ phpredis_version }}_{{ ansible_machine }}.deb"
+  shell: "/var/lib/ansible/phpredis/checkouts/phpredis/mkdeb.sh && mv /var/lib/ansible/phpredis/checkouts/phpredis/phpredis-`git describe --abbrev=0 --tags`_`uname -m`.deb /var/lib/ansible/phpredis/checkouts/phpredis-{{ phpredis_version }}_{{ ansible_machine }}.deb"
   args:
     chdir: "/var/lib/ansible/phpredis/checkouts/phpredis"
     creates: "/var/lib/ansible/phpredis/checkouts/phpredis-{{ phpredis_version }}_{{ ansible_machine }}.deb"


### PR DESCRIPTION
When using branch names for `phpredis_version `, the name of the `*.deb` file is not managed correctly. 
For example, branch `develop` generates a file named `phpredis-2.2.8-rc1_x86_64.deb`.

I used the same code as in [mkdeb.sh](https://github.com/phpredis/phpredis/blob/5f9cc57f8b86326cbf6d8654992ad8135512cfbc/mkdeb.sh#L20) to get the actual file name. 

Also, when `build deb file` fails, the Git repo get modified anyway, and the task cannot run again, so I used `force: yes`.

```
Local modifications exist in repository (force=no)
```